### PR TITLE
Change "PII" to "personal data".

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,17 +619,17 @@
 
     <section class="informative">
       <h3>
-        Dealing with Personally Identifiable Information (PII)
+        Dealing with Personal Data
       </h3>
 
       <p class="advisement">
-        Never store PII, even in an encrypted format, on any verifiable data 
+        Never store personal data, even in an encrypted format, on any verifiable data
         registry backed by immutable storage.
       </p>
 
       <p>
         It is the DID method implementer's responsibility to think about and identify
-        the extent to which PII may be included in a DID document.
+        the extent to which personal data may be included in a DID document.
       </p>
 
       <p>
@@ -638,7 +638,7 @@
       </p>
 
       <p>
-        A DID method specification should have a section dedicated to PII covering the extent to
+        A DID method specification should have a section dedicated to personal data covering the extent to
         which information published on the corresponding ledger can be updated or deleted.
         It should provide specific instructions of how to do so, if it is possible.
         Otherwise, it should clearly state that it is not possible.


### PR DESCRIPTION
Just to be consistent with DID Core.

See discussion here: https://github.com/w3c/did-core/issues/590


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-imp-guide/pull/9.html" title="Last updated on May 16, 2021, 8:32 PM UTC (b3e794d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/9/c09432f...peacekeeper:b3e794d.html" title="Last updated on May 16, 2021, 8:32 PM UTC (b3e794d)">Diff</a>