### PR TITLE
Use ReSpec index feature for Terminology section

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,14 @@
 
    <section id="conformance"></section>
 
-  <section class="informative">
+  <section id="terminology" class="informative">
     <h2>Terminology</h2>
-    <div data-include="https://w3c.github.io/did-core/terms.html"></div>
+    <p>
+      See [[DID-CORE]] for definitions of commonly-used
+      <a data-cite="did-core#terminology">DID terminology</a>.
+    </p>
+
+    <section id="index"></section>
   </section>
 
   <section class="informative">


### PR DESCRIPTION
Instead of importing the terms from DID Core, we could use ReSpec's [index generation](https://respec.org/docs/#id-index) feature. This results in a list of each term that is referenced in the document.

Applied onto #20, it looks like this:
![did-imp-guide-terminology-fd428ef-399e9e0](https://user-images.githubusercontent.com/95347/129435101-fdef3032-0c92-4e8e-89ee-46a73a93f017.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clehner/did-imp-guide/pull/21.html" title="Last updated on Aug 14, 2021, 5:26 AM UTC (fd428ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/21/d5b8ee6...clehner:fd428ef.html" title="Last updated on Aug 14, 2021, 5:26 AM UTC (fd428ef)">Diff</a>