### PR TITLE
Encourage DID method reuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       // the specification's short name, as in http://www.w3.org/TR/short-name/
       shortName: "did-imp-guide",
       xref: {
-        specs: ["DID-CORE", "VC-DATA-MODEL", "DID-CBOR-REPRESENTATION", "did-spec-registries", "RFC4086", "RFC4880", "RFC6838", "RFC8259", "RFC8446", "RFC8174", "RFC2119"],
+        specs: ["DID-CORE", "VC-DATA-MODEL", "DID-CBOR-REPRESENTATION", "DID-RUBRIC", "did-spec-registries", "RFC4086", "RFC4880", "RFC6838", "RFC8259", "RFC8446", "RFC8174", "RFC2119"],
         profile: "web-platform",
       },
 
@@ -208,6 +208,29 @@
       Together these determine most of the unique properties of a DID method,
       and its privacy and security properties for comparison to other methods.
     </p>
+
+    <section class="informative">
+      <h3>Method Reuse Encouraged</h3>
+      <p>
+        While decentralization is desired in many ways, some convergence upon
+        widely useful DID methods is considered beneficial.
+        If you are considering defining a new DID method, consider first
+        surveying existing defined DID methods to see if there may be an
+        already existing method that may meet your needs. Many DID method
+        specifications can be found listed in the [[DID-SPEC-REGISTRIES]]. Some
+        DID methods are evaluated against various criteria in the
+        [[DID-RUBRIC]]. Some DID methods have implementation data in the
+        <a href="https://github.com/w3c/did-test-suite/">DID Test Suite</a>,
+        which could be useful as references for some criteria. If no existing
+        DID method fully meets your needs, but some appear that they may be
+        modifiable or extensible to do so, consider contacting the DID method
+        specification author(s), or otherwise following established procedures,
+        to see if collaboration may be possible to support your use case. Some
+        DID methods have built-in extensibility points such as through
+        registry-like mechanisms, to support new key types, discovery methods,
+        etc.
+      </p>
+    </section>
 
     <section class="informative">
       <h3>DID Syntax</h3>

--- a/index.html
+++ b/index.html
@@ -210,9 +210,9 @@
     </p>
 
     <section class="informative">
-      <h3>Method Reuse Encouraged</h3>
+      <h3>Method Reuse is Encouraged</h3>
       <p>
-        While decentralization is desired in many ways, some convergence upon
+        While many forms of decentralization are desired, some convergence upon
         widely useful DID methods is considered beneficial.
         If you are considering defining a new DID method, consider first
         surveying existing defined DID methods to see if there may be an

--- a/index.html
+++ b/index.html
@@ -218,16 +218,16 @@
         surveying existing defined DID methods to see if there may be an
         already existing method that may meet your needs. Many DID method
         specifications can be found listed in the [[DID-SPEC-REGISTRIES]]. Some
-        DID methods are evaluated against various criteria in the
+        DID methods have been evaluated against various criteria in the
         [[DID-RUBRIC]]. Some DID methods have implementation data in the
         <a href="https://github.com/w3c/did-test-suite/">DID Test Suite</a>,
         which could be useful as references for some criteria. If no existing
         DID method fully meets your needs, but some appear that they may be
         modifiable or extensible to do so, consider contacting the DID method
-        specification author(s), or otherwise following established procedures,
+        specification author(s) or following other established procedures
         to see if collaboration may be possible to support your use case. Some
-        DID methods have built-in extensibility points such as through
-        registry-like mechanisms, to support new key types, discovery methods,
+        DID methods have built-in extensibility points (such as
+        registry-like mechanisms) to support new key types, discovery methods,
         etc.
       </p>
     </section>


### PR DESCRIPTION
This started out with trying to expand or justify the statement "Avoid constructing a new DID Method that is nearly identical to an existing DID Method." but I thought it might make more sense as a subsection.

This includes adding a reference to the DID Rubric and a link to the DID Test Suite.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clehner/did-imp-guide/pull/28.html" title="Last updated on Sep 3, 2021, 3:51 PM UTC (8f33538)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/28/993dac9...clehner:8f33538.html" title="Last updated on Sep 3, 2021, 3:51 PM UTC (8f33538)">Diff</a>