### PR TITLE
Add explicit reference to did rubric

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,14 @@
       and its privacy and security properties for comparison to other methods.
     </p>
 
+    <p class="advisement">
+      Developers are encouraged to utilize the [[DID-RUBRIC]] as early as poosible
+      in the development process to ensure that they are considering and assessing 
+      their DID method against appropriate methods for evaluating a DID Method
+      by the requirements driven by the problem they are attempting to solve with
+      the introduction of a new DID method.
+    </p>
+
     <section class="informative">
       <h3>Method Reuse is Encouraged</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -212,8 +212,8 @@
     <p class="advisement">
       Developers are encouraged to utilize the [[DID-RUBRIC]] as early as poosible
       in the development process to ensure that they are evaluating their DID method 
-      appropriately by the requirements given by the problem they are attempting to 
-      solve with the introduction of a new DID method.
+      appropriately by the requirements as given by the problem they are attempting 
+      to solve with the introduction of a new DID method.
     </p>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -211,10 +211,9 @@
 
     <p class="advisement">
       Developers are encouraged to utilize the [[DID-RUBRIC]] as early as poosible
-      in the development process to ensure that they are considering and assessing 
-      their DID method against appropriate methods for evaluating a DID Method
-      by the requirements driven by the problem they are attempting to solve with
-      the introduction of a new DID method.
+      in the development process to ensure that they are evaluating their DID method 
+      appropriately by the requirements given by the problem they are attempting to 
+      solve with the introduction of a new DID method.
     </p>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
     <p class="advisement">
       DID method developers are encouraged to review and apply the
       [[DID-RUBRIC]] as early as possible in their development process to
-      ensure that they are evaluating their DID method appropriately by the
+      ensure that they are evaluating their DID method appropriately for the
       requirements of the problem they are attempting to solve with the
       introduction of a new DID method.
     </p>

--- a/index.html
+++ b/index.html
@@ -210,10 +210,11 @@
     </p>
 
     <p class="advisement">
-      Developers are encouraged to utilize the [[DID-RUBRIC]] as early as poosible
-      in the development process to ensure that they are evaluating their DID method 
-      appropriately by the requirements as given by the problem they are attempting 
-      to solve with the introduction of a new DID method.
+      DID method developers are encouraged to review and apply the
+      [[DID-RUBRIC]] as early as possible in their development process to
+      ensure that they are evaluating their DID method appropriately by the
+      requirements of the problem they are attempting to solve with the
+      introduction of a new DID method.
     </p>
 
     <section class="informative">


### PR DESCRIPTION
This can serve as a basis to then link to other sections of the rubric throughout the implementation guide


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mesur-io/did-imp-guide/pull/31.html" title="Last updated on Sep 14, 2021, 8:09 PM UTC (0f0b9cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/31/967cb7d...mesur-io:0f0b9cb.html" title="Last updated on Sep 14, 2021, 8:09 PM UTC (0f0b9cb)">Diff</a>