### PR TITLE
Update of `respecConfig`

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,7 @@
   <script type="text/javascript" class="remove">
     var respecConfig = {
       // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
-      specStatus: "FPWD-NOTE",
-      publishDate: "2021-08-26",
+      specStatus: "WG-NOTE",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
       shortName: "did-imp-guide",


### PR DESCRIPTION
1. The specification status should say `WG-NOTE` now and not `FPWD-NOTE`
2. Removed the publication date, see https://github.com/w3c/did-imp-guide/pull/27#issuecomment-930875433


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/pull/34.html" title="Last updated on Sep 30, 2021, 7:00 AM UTC (7a9dcfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-imp-guide/34/a5cda54...7a9dcfe.html" title="Last updated on Sep 30, 2021, 7:00 AM UTC (7a9dcfe)">Diff</a>