### PR TITLE
Add links to external evaluation and conference paper.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1467,6 +1467,13 @@ keyAgreement:
         <a href="/reports/did-sec-priv-criteria-overview-public.pdf">Approach to Developing Security and Privacy Assessment
           Criteria for Decentralized Identifiers</a>
       </li>
+      <li>
+        <a href="https://eprint.iacr.org/2021/1087">Methods for Decentralized Identities: Evaluation and Insights</a>
+      </li>
+      <li>
+        <a href="https://docs.google.com/document/d/1jP-76ul0FZ3H8dChqT2hMtlzvL6B3famQbseZQ0AGS8/">External Evaluation of
+          DID Methods using the DID Rubric</a>
+      </li>
     </ul>
 
   </section>


### PR DESCRIPTION
This is a replacement for https://github.com/w3c/did-rubric/pull/47, where the recommendation was to move these resources to the DID Implementation Guide.